### PR TITLE
Prevent doc comments on structs from interfering with macro

### DIFF
--- a/src/args_parsing.rs
+++ b/src/args_parsing.rs
@@ -150,20 +150,20 @@ impl StructArgs {
         let mut default_epsilon_value = None;
         let mut default_max_relative_value = None;
         for attribute in attributes.iter() {
-            let arg: StructArgGeneric = attribute.parse_args()?;
-            match arg {
-                StructArgGeneric::Value(StructValueArg::None) => (),
-                StructArgGeneric::KeyValue(StructKeyValueArg::EpsilonType(epsilon_ty)) => {
+            match attribute.parse_args() {
+                Ok(StructArgGeneric::Value(StructValueArg::None)) => (),
+                Ok(StructArgGeneric::KeyValue(StructKeyValueArg::EpsilonType(epsilon_ty))) => {
                     epsilon_type = Some(epsilon_ty)
                 }
-                StructArgGeneric::KeyValue(StructKeyValueArg::DefaultEpsilon(default_eps)) => {
+                Ok(StructArgGeneric::KeyValue(StructKeyValueArg::DefaultEpsilon(default_eps))) => {
                     default_epsilon_value = Some(default_eps)
                 }
-                StructArgGeneric::KeyValue(StructKeyValueArg::DefaultMaxRelative(
+                Ok(StructArgGeneric::KeyValue(StructKeyValueArg::DefaultMaxRelative(
                     default_max_rel,
-                )) => {
+                ))) => {
                     default_max_relative_value = Some(default_max_rel);
                 }
+                Err(_) => {}
             }
         }
         Ok(Self {

--- a/tests/derive_abs_diff.rs
+++ b/tests/derive_abs_diff.rs
@@ -2,6 +2,7 @@ use approx_derive::*;
 
 #[test]
 fn derive_abs_diff_eq() {
+    /// Struct definition
     #[derive(AbsDiffEq, PartialEq, Debug)]
     struct MyStruct {
         value: f64,
@@ -35,6 +36,7 @@ fn derive_abs_diff_eq_cast_field() {
 
 #[test]
 fn derive_abs_diff_eq_cast_field_2() {
+    /// Struct definition
     #[derive(AbsDiffEq, PartialEq, Debug)]
     #[approx(epsilon_type = f32)]
     struct MyStructCast2 {

--- a/tests/derive_rel_diff.rs
+++ b/tests/derive_rel_diff.rs
@@ -2,6 +2,7 @@ use approx_derive::*;
 
 #[test]
 fn derive_rel_diff_eq() {
+    /// Struct definition
     #[derive(RelativeEq, PartialEq, Debug)]
     struct MyStruct {
         value: f64,


### PR DESCRIPTION
Thank you for providing this crate. I would love to use it, but it seems like adding a doc comment to a struct on which e.g. `RelativeEq` is derived results in an error:

```
expected parentheses: #[doc(...)]
```

I believe I fixed this in this PR.